### PR TITLE
Add mariadb client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN set -xe \
 	&& yum install -y yum-plugin-copr \
 	&& yum copr enable -y mbrancaleoni/erlang \
 	&& yum install -y ${NODESOURCE} \
-	&& yum install -y rpm-build createrepo epel-release make git lsof openssh-clients which nodejs sox openssl \
+	&& yum install -y rpm-build createrepo epel-release make git lsof openssh-clients which nodejs sox openssl mariadb \
 	&& yum groups mark install "Development Tools" \
 	&& yum groups mark convert "Development Tools" \
 	&& yum groupinstall -y "Development Tools" \


### PR DESCRIPTION
`mariadb` package is installed to provide the `mysql` command needed by ecto to import existing SQL dumps (reference: https://hexdocs.pm/ecto_sql/Mix.Tasks.Ecto.Load.html)